### PR TITLE
Fix typo in Optional_Quint.deserialize

### DIFF
--- a/wsjtx_srv/wsjtx.py
+++ b/wsjtx_srv/wsjtx.py
@@ -98,7 +98,7 @@ class Optional_Quint (Protocol_Element):
         if len (bytes) == 0:
             value = None
         else:
-            value = unpack (self.formats [length], bytes) [0]
+            value = unpack (cls.formats [length], bytes) [0]
         object = cls (value)
         object.size = length
         if value is None:


### PR DESCRIPTION
My linter caught this error while I was working on a script using the library.

I haven't actually seen a crash for it yet tho, so I suppose it isn't a commonly used code-path.