### PR TITLE
Use plaintext version file during setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ endif
 LASTRELEASE:=$(shell $(RELEASETOOLS)/lastrelease -n)
 WSJTX=wsjtx.py __init__.py
 VERSIONPY=wsjtx_srv/Version.py
-VERSION=$(VERSIONPY)
+VERSIONTXT=wsjtx_srv/VERSION
+VERSION=$(VERSIONPY) $(VERSIONTXT)
 README=README.rst
 SRC=Makefile setup.py $(WSJTX:%.py=wsjtx_srv/%.py) \
     MANIFEST.in $(README) README.html
@@ -23,7 +24,7 @@ all: $(VERSION)
 $(VERSION): $(SRC)
 
 clean:
-	rm -f MANIFEST wsjtx_srv/Version.py notes changes default.css    \
+	rm -f MANIFEST ${VERSION} notes changes default.css    \
 	      README.html README.aux README.dvi README.log README.out \
 	      README.tex announce_pypi
 	rm -rf dist build upload upload_homepage ReleaseNotes.txt \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,4 +62,4 @@ wsjtx-srv = 'wsjtx_srv.wsjtx:main'
 wbf       = 'wsjtx_srv.wsjtx:wbf'
 
 [tool.setuptools.dynamic]
-version = {attr = "wsjtx_srv.__version__"}
+version = {file = "wsjtx_srv/VERSION"}

--- a/setup.py
+++ b/setup.py
@@ -28,12 +28,16 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # ****************************************************************************
 
-import sys
+import os.path
 from setuptools import setup
-sys.path.insert (1, '.')
-from wsjtx_srv import __version__
 
-with open ('README.rst') as f:
+if os.path.exists ("VERSION"):
+    with open ("VERSION", 'r', encoding="utf8") as f:
+        __version__ = f.read ().strip ()
+else:
+    __version__ = '0+unknown'
+
+with open ('README.rst', encoding="utf8") as f:
     description = f.read ()
 
 license     = 'BSD License'

--- a/wsjtx_srv/.gitignore
+++ b/wsjtx_srv/.gitignore
@@ -1,1 +1,2 @@
 Version.py
+VERSION

--- a/wsjtx_srv/__init__.py
+++ b/wsjtx_srv/__init__.py
@@ -1,21 +1,4 @@
-import os.path
-import inspect
-
-def called_from_pip_or_build ():
-    sep  = os.path.sep
-    comp = os.path.normpath (inspect.stack () [-1].filename).split (sep)
-    if 'pip' in comp and '_vendor' in comp and 'pyproject_hooks' in comp:
-        return True
-    if 'pep517' in comp:
-        return True
-    return False
-
-try:
-    from .wsjtx   import *
-except ImportError:
-    if not called_from_pip_or_build ():
-        raise
-
+from .wsjtx   import *
 
 try:
     from .Version import VERSION as __version__


### PR DESCRIPTION
Use plaintext version file during setup instead of importing from the package,
which will fail when dependencies are not yet installed.


Depends on schlatterbeck/releasetool#1


There are alternatives, such as
- Having the version script update the version number in the `setup.py` and `pyproject.toml`
- Adding the dependencies to build-system.requires in `pyproject.toml`
  I have not tested this, but this should help for pyproject based builds at least. May or may not help with direct pip install.