### PR TITLE
Add pytest config for autodetection of doctests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,3 +63,6 @@ wbf       = 'wsjtx_srv.wsjtx:wbf'
 
 [tool.setuptools.dynamic]
 version = {file = "VERSION"}
+
+[tool.pytest.ini_options]
+addopts = '--doctest-modules'


### PR DESCRIPTION
Allows simply running `pytest` without arguments.
With this change, vscode autodetects the doctest tests (when configured to use pytest).

Alternative location is under the `[pytest]` section in `pytest.ini` or `tox.ini`.